### PR TITLE
Handle ranges (≤) in versions

### DIFF
--- a/scripts/update-issues.ts
+++ b/scripts/update-issues.ts
@@ -71,9 +71,10 @@ const dateFormat = new Intl.DateTimeFormat("en", { dateStyle: "medium" });
 function issueBody(id: string, data: (typeof features)[string]) {
   const supportLines = [];
   for (const [browser, { name, releases }] of Object.entries(browsers)) {
-    const version = data.status.support[browser];
-    if (version) {
-      const date = releases.find((r) => r.version === version)!.date;
+    const version = data.status.support[browser as keyof typeof browsers];
+    const v = version?.replace("≤", "");
+    if (v) {
+      const date = releases.find((r) => r.version === v)!.date;
       const dateString = dateFormat.format(new Date(date));
       supportLines.push(`${name} ${version} (${dateString})`);
     } else {


### PR DESCRIPTION
These only appear before 2020 in BCD and are quite rare, so keep things
simple by just removing the ranges. This is what MDN does as well.
