### PR TITLE
Update issues for newly Baseline features

### DIFF
--- a/scripts/update-issues.ts
+++ b/scripts/update-issues.ts
@@ -285,11 +285,13 @@ async function update() {
 
     const skipReason = skipFeatures.get(id);
     if (skipReason) {
+      // TODO: Handle skipped features that already have open issues.
       console.log(`Skipping ${id}. Reason: ${skipReason}`);
       continue;
     }
 
     if (data.discouraged) {
+      // TODO: Handle skipped features that already have open issues.
       console.log(
         `Skipping ${id}. Reason: Discouraged according to ${data.discouraged.according_to[0]}`,
       );

--- a/scripts/update-issues.ts
+++ b/scripts/update-issues.ts
@@ -293,17 +293,17 @@ async function update() {
       continue;
     }
 
-    if (data.status.baseline) {
+    const title = data.name;
+    const body = issueBody(id, data);
+    const issue = openIssues.get(id);
+    
+    if (data.status.baseline && !issue) {
       console.log(
         `Skipping ${id}. Reason: Baseline since ${data.status.baseline_low_date}`,
       );
       continue;
     }
 
-    const title = data.name;
-    const body = issueBody(id, data);
-
-    const issue = openIssues.get(id);
     if (issue) {
       if (issue.title !== title || issue.body !== body) {
         // Update the issue. This might happen as a result of a change in

--- a/scripts/update-issues.ts
+++ b/scripts/update-issues.ts
@@ -66,7 +66,10 @@ async function* iterateIssues(octokit: Octokit, params: IterateIssuesParams) {
   }
 }
 
-const dateFormat = new Intl.DateTimeFormat("en", { dateStyle: "medium" });
+const dateFormat = new Intl.DateTimeFormat("en", { 
+  dateStyle: "medium",
+  timeZone: "UTC" 
+});
 
 function issueBody(id: string, data: (typeof features)[string]) {
   const supportLines = [];


### PR DESCRIPTION
Progress on #388

Only ignore Baseline features that don't already have open issues. This way, when a feature becomes Baseline, its browser support info will be updated accordingly.

This also fixes a bug where the browser release dates would change depending on the timezone you're running the script in.

Excerpt from dry mode:

> Issue for window-controls-overlay is up-to-date.
> Skipping calc-constants. Reason: Baseline since 2023-06-06
> Skipping array-by-copy. Reason: Baseline since 2023-07-04
> Skipping animation-composition. Reason: Baseline since 2023-07-04
> Skipping webxr-camera. Reason: oppose position at https://github.com/WebKit/standards-positions/issues/37
> Dry run. Would update issue for content-visibility.
> Skipping origin-private-file-system. Reason: Baseline since 2023-03-27
> Skipping color-mix. Reason: Baseline since 2023-05-09
> Skipping gradient-interpolation. Reason: Baseline since 2024-06-11
> Skipping lh. Reason: Baseline since 2023-11-21
> Issue for hyphenate-limit-chars is up-to-date.