### PR TITLE
Fix dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,7 @@
 version: 2
 updates:
   - package-ecosystem: "npm"
-    directory: "/"
+    directory: "**/*"
     schedule:
       interval: "daily"
     allow:


### PR DESCRIPTION
I broke the dependabot config in #416:

> Update configs must have a unique combination of 'package-ecosystem', 'directory', and 'target-branch'. Ecosystem 'npm' has overlapping directories.

https://github.com/web-platform-dx/developer-signals/network/updates

This PR attempts to work around that error by using a slightly different `directory` value, which should let us have two unique schedules for npm packages: daily for web-features, weekly for everything else.

Testing this locally with `npx @bugron/validate-dependabot-yaml@latest` works, but if dependabot is still broken then we should just put everything on a daily schedule and increase the limit from 5 to 10 open PRs.