### PR TITLE
Another dependabot fix

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,8 @@
 version: 2
 updates:
   - package-ecosystem: "npm"
-    directory: "**/*"
+    directories:
+      - "**/*"
     schedule:
       interval: "daily"
     allow:


### PR DESCRIPTION
Attempt to fix the dependabot error Once And For All<sup>TM</sup> by moving from `directory` to `directories`

Context on why the last attempt failed: https://github.com/web-platform-dx/developer-signals/pull/417#issuecomment-3411435804

This SHOULD fix the error. The local tests are passing, but the previous attempt proves that we can't trust it. If this still doesn't work, my last resort is to have a single daily config for all dependencies with an increased limit on open PRs.