### PR TITLE
Final dependabot fix

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,15 +1,7 @@
 version: 2
 updates:
   - package-ecosystem: "npm"
-    directories:
-      - "**/*"
-    schedule:
-      interval: "daily"
-    allow:
-      - dependency-name: "web-features"
-  - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "weekly"
-    ignore:
-      - dependency-name: "web-features"
+      interval: "daily"
+    open-pull-requests-limit: 10


### PR DESCRIPTION
Fixes #411 (again)

- a single config for all dependencies
- daily check for updates
- increased limit of 10 open PRs

The increased limit is necessary because we're already at 5 open PRs (the default) which is preventing new web-features updates.

