### PR TITLE
Prevent concurrent runs of the update-issues workflow

### DIFF
--- a/.github/workflows/update-issues.yml
+++ b/.github/workflows/update-issues.yml
@@ -7,6 +7,9 @@ on:
     branches:
       - main
   workflow_dispatch:
+concurrency:
+  group: update-issues
+  cancel-in-progress: true
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This is based on these docs:
https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/control-workflow-concurrency