### PR TITLE
Refresh README to explain current repo usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,19 @@
-# developer-signals: tracking web developer signals
+# Collecting web developer signals for non-Baseline features
 
-This project tracks organize developer signals (interest, needs, wants, frustrations) around web platform features. The work is done within the [W3C WebDX Community Group](https://www.w3.org/community/webdx/).
+This project collects web developer signals (interest, needs, wants) for web platform features that are not yet [Baseline](https://web-platform-dx.github.io/web-features/). The work is done within the [W3C WebDX Community Group](https://www.w3.org/community/webdx/).
 
-Signals is defined broadly to allow for any available data about web developers to be considered, and typically fall into one of these categories:
+The repository contains an [open issue](https://github.com/web-platform-dx/developer-signals/issues?q=is%3Aissue%20state%3Aopen%20label%3Afeature) for each Web platform feature defined in [`web-features`](https://github.com/web-platform-dx/web-features) that is neither Baseline nor discouraged. Issues collect use cases for the feature and expressions of support through thumbs up reactions (👍).
+
+[Weekly digests](https://www.w3.org/Search/Mail/Public/search?keywords=+developer-signals+digest&lists=public-webdx) that summarize recent activity in the repository are sent to the public mailing-list of the WebDX Community Group (`public-webdx@w3.org`). A [`web-features-signals.json`](https://web-platform-dx.github.io/developer-signals/web-features-signals.json) file is also updated on a daily basis with the total number of upvotes per feature.
+
+Signals collected in this repository are intended to complete signals collected through other means, including:
 
 - Survey results, for example from [State of CSS](https://stateofcss.com/) or [MDN short surveys](https://github.com/web-platform-tests/interop/issues/245)
 - Developer interviews, such as those done for the [MDN Browser Compatibility Report 2020](https://mdn.dev/archives/insights/reports/mdn-browser-compatibility-report-2020.html)
 - Browser bugs, including upvote/star counts
-- Reactions on GitHub issues relating to web platform features
 - Blogs, podcasts, or social media
 
-To the extent possible, signals will be organized around [`web-features`](https://github.com/web-platform-dx/web-features).
-
-This project is only about organizing signals, not about conducting or coordinating research. For that, see the [WebDX research workstream](https://github.com/web-platform-dx/developer-research).
+This project is only about collecting signals around web platform features, not about conducting or coordinating more thorough research. For that, see the [WebDX research workstream](https://github.com/web-platform-dx/developer-research).
 
 ## Background
 


### PR DESCRIPTION
The README was created at a time when the repository was primarily meant to coordinate developer signals. The repository is now primarily used to collect developer signals for features that are not yet Baseline.

This adjusts the README accordingly.