### PR TITLE
Sanitize group names before assigning as GitHub labels

### DIFF
--- a/scripts/update-issues.ts
+++ b/scripts/update-issues.ts
@@ -243,10 +243,10 @@ function getGroupLabels(data: (typeof features)[string]): string[] {
       const groupData: { name: string; parent?: string } | undefined =
         groups[currentId as keyof typeof groups];
       if (groupData) {
-        groupNames.add(groupData.name);
+        groupNames.add(groupData.name.replaceAll(",", ""));
         currentId = groupData.parent;
       } else {
-        groupNames.add(currentId);
+        groupNames.add(currentId.replaceAll(",", ""));
         break;
       }
     }


### PR DESCRIPTION
For example, this renames `"Clipping, shapes, and masking"` to `"Clipping shapes and masking"`

Tested with `npx tsx scripts/update-issues.ts --dry-run` successfully